### PR TITLE
allow setting the password on the commandline

### DIFF
--- a/sparqlmap-client/src/main/java/org/aksw/sparqlmap/config/ConfigBeanDataSource.java
+++ b/sparqlmap-client/src/main/java/org/aksw/sparqlmap/config/ConfigBeanDataSource.java
@@ -26,7 +26,7 @@ public class ConfigBeanDataSource {
   private String dbName;
   @Parameter(names={"-u","--ds.username"},description="For data sources that require authentication")
   private String username;
-  @Parameter(names={"-p","--ds.password"}, password = true, description="For data sources that require authentication")
+  @Parameter(names={"-p","--ds.password"}, description="For data sources that require authentication")
   private String password;
   @Parameter(names={"--ds.maxPoolSize"})
   private Integer maxPoolSize = 10;


### PR DESCRIPTION
In the readme you show that the password can be passed on the command line. The `password = true` lead to the situation, that the password is requested interactively.
By removing this argument the password can be provided on the commandline which allows to use sparqlmap in a script.